### PR TITLE
Fixing bug on plot_multiple_distplot() function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ reqs = [str(ir.req) for ir in install_reqs]"""
 # Criando setup
 setup(
     name='xplotter',
-    version='0.0.4',
+    version='0.0.5',
     author='Thiago Panini',
     author_email='thipanini94@gmail.com',
     packages=find_packages(),

--- a/xplotter/insights.py
+++ b/xplotter/insights.py
@@ -1377,6 +1377,7 @@ def plot_multiple_distplots(df, col_list, n_cols=3, kind='dist', **kwargs):
     i, j = 0, 0
     
     # Extracting additional parameters for the charts
+    hue = kwargs['hue'] if 'hue' in kwargs else None
     hist = kwargs['hist'] if 'hist' in kwargs else True
     kde = kwargs['kde'] if 'kde' in kwargs else True
     rug = kwargs['rug'] if 'rug' in kwargs else False


### PR DESCRIPTION
The bug was found when trying to execute the plot_multiple_distplot() function and passing the `hue` paramteres through kwargs dictionary. When this function tries do call plot_distplot() the error occurs because `hue` is not being returned from kwargs. This merge requests contains the fix on code for that.